### PR TITLE
Enable (this image) preloading for Firefox

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,6 +43,11 @@ a:hover {
     display: none;
 }
 
+.fullscreen.hidden {
+    display: block;
+    z-index: -1000;
+}
+
 #this-image {
     background:#000000 url('this-image.png') center no-repeat;
     background-size: contain;


### PR DESCRIPTION
When an element has `display: hidden` in Firefox, their background image isn't loaded automatically. Changing the way to hide _this image_ and _that video_ to be in the far background (`z-index: -1000`), Firefox will include the images in the loading of the page, ensuring they are loaded when you start to play _this audio_.